### PR TITLE
Updated dead link.

### DIFF
--- a/security.php
+++ b/security.php
@@ -89,7 +89,7 @@ $page[ 'body' ] .= "
 
 	<h2>PHPIDS</h2>
 
-	<p>".dvwaExternalLinkUrlGet( 'http://php-ids.org/', 'PHPIDS' )." v.".dvwaPhpIdsVersionGet()." (PHP-Intrusion Detection System) is a security layer for PHP based web applications. </p>
+	<p>".dvwaExternalLinkUrlGet( 'http://phpids.org/', 'PHPIDS' )." v.".dvwaPhpIdsVersionGet()." (PHP-Intrusion Detection System) is a security layer for PHP based web applications. </p>
 	<p>You can enable PHPIDS across this site for the duration of your session.</p>
 
 	<p>{$phpIdsHtml}</p>


### PR DESCRIPTION
The link to PHPIDS was incorrect (http://php-ids.org/), but I've updated it to the correct url (http://phpids.org/)!